### PR TITLE
Open browser to docs url on nox -s docs -- serve

### DIFF
--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import tempfile
+import webbrowser
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -331,6 +332,7 @@ def docs(session: nox.Session) -> None:
     poetry_install(session, *requirements)
 
     if "serve" in session.posargs:
+        webbrowser.open(url="http://127.0.0.1:8000/{{cookiecutter.project_slug}}/")
         session.run("mkdocs", "serve")
     else:
         session.run("mkdocs", "build", "--clean")


### PR DESCRIPTION
nox `docs` session now opens browser to the served docs url if `-- serve` is used