### PR TITLE
Add pytestArgs to nox dev session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -131,6 +131,7 @@ def set_up_vscode(session: nox.Session) -> None:
         settings = {
             "python.defaultInterpreterPath": PYTHON,
             "python.testing.pytestEnabled": True,
+            "python.testing.pytestArgs": ["tests"],
         }
 
         with open(SETTINGS_JSON, mode="w", encoding="utf-8") as f:

--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -155,6 +155,7 @@ def set_up_vscode(session: nox.Session) -> None:
         settings = {
             "python.defaultInterpreterPath": PYTHON,
             "python.testing.pytestEnabled": True,
+            "python.testing.pytestArgs": ["tests"],
         }
 
         with open(SETTINGS_JSON, mode="w", encoding="utf-8") as f:


### PR DESCRIPTION
Add `pytestArgs` to VSCode workspace settings on the `dev` nox session.